### PR TITLE
fix(location): Use LocationManager instead of FusedLocationProviderClient

### DIFF
--- a/app/src/main/java/com/flockyou/service/ScanningService.kt
+++ b/app/src/main/java/com/flockyou/service/ScanningService.kt
@@ -26,7 +26,6 @@ import com.flockyou.detection.DetectionRegistry
 import com.flockyou.detection.handler.BleDetectionHandler
 import com.flockyou.detection.handler.CellularDetectionHandler
 import com.flockyou.detection.handler.SatelliteDetectionHandler
-import com.google.android.gms.location.*
 import com.google.gson.Gson
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.*
@@ -270,7 +269,7 @@ class ScanningService : Service() {
     private var wifiScanReceiver: BroadcastReceiver? = null
 
     // Location
-    private lateinit var fusedLocationClient: FusedLocationProviderClient
+
     internal var currentLocation: Location? = null
 
     // Vibration
@@ -543,8 +542,6 @@ class ScanningService : Service() {
         // Initialize WiFi
         wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
 
-        // Initialize Location
-        fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
 
         // Initialize Vibrator
         vibrator = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -1874,7 +1871,6 @@ class ScanningService : Service() {
     }
 
     // ==================== Location ====================
-
     @SuppressLint("MissingPermission")
     private fun updateLocation() {
         if (!hasLocationPermissions()) {
@@ -1882,21 +1878,47 @@ class ScanningService : Service() {
             return
         }
 
-        fusedLocationClient.lastLocation
-            .addOnSuccessListener { location ->
-                currentLocation = location
-                locationStatus.value = if (location != null) {
-                    SubsystemStatus.Active
-                } else {
-                    SubsystemStatus.Error(-1, "No location available")
-                }
+        val locationManager = getSystemService(Context.LOCATION_SERVICE) as android.location.LocationManager
+
+        // Try last known first
+        val lastKnown = locationManager.getLastKnownLocation(android.location.LocationManager.GPS_PROVIDER)
+            ?: locationManager.getLastKnownLocation(android.location.LocationManager.FUSED_PROVIDER)
+            ?: locationManager.getLastKnownLocation(android.location.LocationManager.NETWORK_PROVIDER)
+
+        if (lastKnown != null) {
+            currentLocation = lastKnown
+            locationStatus.value = SubsystemStatus.Active
+            return
+        }
+
+        // No last known — request a single update
+        val providers = listOf(
+            android.location.LocationManager.GPS_PROVIDER,
+            android.location.LocationManager.NETWORK_PROVIDER
+        )
+
+        for (provider in providers) {
+            if (locationManager.isProviderEnabled(provider)) {
+                locationManager.requestSingleUpdate(
+                    provider,
+                    object : android.location.LocationListener {
+                        override fun onLocationChanged(location: android.location.Location) {
+                            currentLocation = location
+                            locationStatus.value = SubsystemStatus.Active
+                        }
+                        override fun onProviderDisabled(provider: String) {}
+                        override fun onProviderEnabled(provider: String) {}
+                    },
+                    android.os.Looper.getMainLooper()
+                )
+                locationStatus.value = SubsystemStatus.Active
+                return
             }
-            .addOnFailureListener { e ->
-                Log.e(TAG, "Failed to get location", e)
-                locationStatus.value = SubsystemStatus.Error(-1, e.message ?: "Location error")
-                logError("Location", -1, "Failed to get location: ${e.message}", recoverable = true)
-            }
+        }
+
+        locationStatus.value = SubsystemStatus.Error(-1, "No location available")
     }
+
 
     // ==================== Detector Health Management ====================
 


### PR DESCRIPTION
## Problem
On GrapheneOS (and other ROMs without Google Play Services), the Location 
subsystem always shows Error(code=-1, message=No location available). This 
is because FusedLocationProviderClient requires Play Services, which returns 
null silently when unavailable.

All other subsystems (BLE, WiFi, Cellular, Satellite, GNSS) work correctly — 
only the location stamping on detections was broken.

## Fix
Replace FusedLocationProviderClient with Android's native LocationManager, 
which works on any AOSP-based ROM without Play Services dependency.

Falls back through GPS → FUSED → NETWORK providers, and requests a single 
update if no last known location is cached.

## Tested on
- Google Pixel 8
- GrapheneOS (Android 16, API 36)
- No Sandboxed Play Services installed

Before: Location → Error(code=-1)
After: Location → Active, detections stamped with coordinates